### PR TITLE
Adding unicode spaces to tokenizer

### DIFF
--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -206,7 +206,7 @@ module Lita::Handlers::Karma
     # modifications, force karma tokens be followed by whitespace (in a zero-
     # width, look-ahead operator) or the end of the string.
     def token_terminator
-      %r{(?:(?=[[:space:]])|$)}
+      %r{(?:(?=[[:space:]])|[.,!)"”]|$)}
     end
   end
 end

--- a/lib/lita/handlers/karma/chat.rb
+++ b/lib/lita/handlers/karma/chat.rb
@@ -206,7 +206,7 @@ module Lita::Handlers::Karma
     # modifications, force karma tokens be followed by whitespace (in a zero-
     # width, look-ahead operator) or the end of the string.
     def token_terminator
-      %r{(?:(?=\s)|[.,!)"”]|$)}
+      %r{(?:(?=[[:space:]])|$)}
     end
   end
 end


### PR DESCRIPTION
This fixes the bug that causes copied and pasted karma not to be interpreted as two separate users